### PR TITLE
Update Slack notification to use Slack app webhook format

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,16 @@ topicArn = "arn:aws:sns:ap-northeast-1:0000000000000:app/EXAMPLE/sample"
 
 [slack]
 # notifytype = slack の場合、以下の設定が有効になります。
+# Slack app の Incoming Webhook URL を使用します。
+# (旧 legacy incoming webhook は非対応です)
 
-# ポストするチャンネル。'#'なしで記述します。
+# 通知先チャンネル。Slack app 側で設定するため、この値はペイロードに含まれません。
 Channel = xxxxx
 
-# slackのwebhookurlを取得して貼り付けます。
-WebhookUrl = http://xxxxxxxxxxxxxx/xxxx
+# Slack app の Incoming Webhook URL を設定します。
+WebhookUrl = https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX
 
-# botのアイコンを変更する場合、アイコンのURLを指定します。
+# botのアイコン設定。Slack app では使用されません（Slack app 側でアイコンを設定してください）。
 IconUrl = http://xxxxxxxxx/xxxxxxxx
 ```
 

--- a/notify/slack.go
+++ b/notify/slack.go
@@ -1,24 +1,22 @@
 package notify
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
-	"net/url"
 )
 
 type Slack struct {
 	Channel    string
 	WebhookUrl string
 	IconUrl    string
-	PostForm   func(string, url.Values) (*http.Response, error)
+	PostJSON   func(url string, contentType string, body io.Reader) (*http.Response, error)
 }
 
 // Slack用のペイロード構造体
 type SlackPayload struct {
-	Channel string `json:"channel"`
-	Text    string `json:"text"`
-	Icon    string `json:"icon_url"`
-	Emoji   string `json:"icon_emoji"`
+	Text string `json:"text"`
 }
 
 // コンストラクタ
@@ -27,7 +25,7 @@ func NewSlack(channel string, webhookUrl string, iconUrl string) *Slack {
 		Channel:    channel,
 		WebhookUrl: webhookUrl,
 		IconUrl:    iconUrl,
-		PostForm:   http.PostForm,
+		PostJSON:   http.Post,
 	}
 
 	return inst
@@ -35,27 +33,15 @@ func NewSlack(channel string, webhookUrl string, iconUrl string) *Slack {
 
 // Slackに通知します。
 func (self *Slack) NotifySlack(message string, status int) error {
-	payload := &SlackPayload{self.Channel, message, "", ""}
+	payload := &SlackPayload{Text: message}
 
-	if self.IconUrl != "" {
-		payload.Icon = self.IconUrl
-	} else {
-		if 0 == status {
-			payload.Emoji = ":simple_smile:"
-		} else {
-			payload.Emoji = ":rage:"
-		}
-	}
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}
 
-	data := url.Values{}
-	data.Add("payload", string(jsonData))
-
-	// Webhool URLにPOSTする
-	_, err = self.PostForm(self.WebhookUrl, data)
+	// Webhook URLにJSON形式でPOSTする (Slack app形式)
+	_, err = self.PostJSON(self.WebhookUrl, "application/json", bytes.NewReader(jsonData))
 	if err != nil {
 		return err
 	}

--- a/notify/slack_test.go
+++ b/notify/slack_test.go
@@ -2,8 +2,8 @@ package notify
 
 import (
 	"fmt"
+	"io"
 	"net/http"
-	"net/url"
 	"testing"
 )
 
@@ -39,26 +39,29 @@ func TestSendSlack(t *testing.T) {
 		url     string
 		iconurl string
 		status  int
-		emoji   string
 		message string
 	}{
-		{"chan", "https://localhost/", "", 0, ":simple_smile:", "smile message to slack"},
-		{"chan", "https://localhost/", "", 1, ":rage:", "rage message to slack"},
-		{"bot", "http://localhost:8080/", "http://localhost/icon.png", 0, "", "message to slack"},
+		{"chan", "https://localhost/", "", 0, "smile message to slack"},
+		{"chan", "https://localhost/", "", 1, "rage message to slack"},
+		{"bot", "http://localhost:8080/", "http://localhost/icon.png", 0, "message to slack"},
 	}
 
 	for _, s := range expecteds {
 		inst := NewSlack(s.channel, s.url, s.iconurl)
-		expectPayload := fmt.Sprintf(`{"channel":"%s","text":"%s","icon_url":"%s","icon_emoji":"%s"}`, s.channel, s.message, s.iconurl, s.emoji)
+		expectPayload := fmt.Sprintf(`{"text":"%s"}`, s.message)
 
-		inst.PostForm = func(url string, data url.Values) (*http.Response, error) {
+		inst.PostJSON = func(url string, contentType string, body io.Reader) (*http.Response, error) {
 			if url != s.url {
 				t.Errorf("(expected) '%s' != '%s'", s.url, url)
 			}
 
-			payload := data["payload"][0]
-			if payload != expectPayload {
-				t.Errorf("(expected) '%s' != '%v'", expectPayload, payload)
+			if contentType != "application/json" {
+				t.Errorf("(expected) 'application/json' != '%s'", contentType)
+			}
+
+			bodyBytes, _ := io.ReadAll(body)
+			if string(bodyBytes) != expectPayload {
+				t.Errorf("(expected) '%s' != '%s'", expectPayload, string(bodyBytes))
 			}
 
 			return nil, nil


### PR DESCRIPTION
Replace legacy incoming webhook (form-encoded payload) with the current
Slack app Incoming Webhook format (JSON body via POST application/json).

Changes:
- notify/slack.go: Replace PostForm with PostJSON, simplify SlackPayload
  to text-only (channel/icon fields are unsupported in new Slack apps)
- notify/slack_test.go: Update mock and assertions for new JSON POST format
- README.md: Note that Channel/IconUrl are not included in the payload

https://claude.ai/code/session_017SrM4NDa4bAH4pHecr3h9L