### PR TITLE
Add Dockerfile and docker-compose for containerized deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# --- Build stage ---
+FROM golang:1.24-bookworm AS builder
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+COPY internal/ internal/
+RUN go mod download
+
+COPY . .
+RUN go build -o gorond .
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/log/gorond /var/pid /etc/goron.d
+
+COPY --from=builder /build/gorond /usr/local/bin/gorond
+
+EXPOSE 6777
+
+CMD ["/usr/local/bin/gorond", "-c", "/etc/goron.conf", "-d", "/etc/goron.d/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  gorond:
+    build: .
+    volumes:
+      - ./docker/goron.conf:/etc/goron.conf:ro
+      - ./docker/goron.d:/etc/goron.d:ro
+      - gorond-logs:/var/log/gorond
+    ports:
+      - "6777:6777"
+    restart: unless-stopped
+
+volumes:
+  gorond-logs:

--- a/docker/goron.conf
+++ b/docker/goron.conf
@@ -1,0 +1,18 @@
+[config]
+# Web API port (accessible at http://localhost:6777)
+webApi = 0.0.0.0:6777
+
+# Log file paths
+log = /var/log/gorond/goron.log
+cronLog = /var/log/gorond/cron.log
+apiLog = /var/log/gorond/api.log
+
+# Notification type: stdout | mail | fluentd | sns | slack
+notifyType = stdout
+
+# Notification timing: onerror | always
+notifyWhen = onerror
+
+[job]
+# Example: run echo every minute as root
+# * * * * * *  root  echo "gorond is running"


### PR DESCRIPTION
- Multi-stage Dockerfile: golang:1.24-bookworm builder + debian:bookworm-slim runtime
- docker-compose.yml mounts config/log volumes and exposes port 6777
- docker/goron.conf: sample config with webApi and stdout notify enabled
- docker/goron.d/: directory for additional job config files

https://claude.ai/code/session_01CUcCMBE6idg2SHLifbPReu